### PR TITLE
add fallback for falsy includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ add commas to numbers.<br /> _note:_  this overrides handlebars-helpers'  `addCo
 add ordinal after a number<br />e.g.  `1`  →  `1st` ,  `2`  →  `2nd` ,  `3`  →  `3rd`
 
 #### Params
-* `i` _(number|string)_ number to add ordinal after
+* `num` _(number|string)_ number to add ordinal after
 
 **Returns** _(string)_ 
 

--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ concatenate any number of strings
 
 ### includes ( [code](https://github.com/clay/handlebars/blob/master/helpers/strings/includes.js) | [tests](https://github.com/clay/handlebars/blob/master/helpers/strings/includes.test.js) )
 
-check if a substring exist within a string. This is very similiar to the<br />indexOf helper, except it uses String.prototype.includes() and returns a<br />boolean.
+check if a substring exist within a string. This is very similiar to the<br />indexOf helper, except it uses String.prototype.includes() and returns a<br />boolean.<br />note: handlebars returns booleans as strings, so only return a value if the substring is found<br />otherwise, return undefined (rather than false)
 
 #### Params
 * `string` _(string)_ 

--- a/README.md
+++ b/README.md
@@ -860,8 +860,6 @@ check if a substring exist within a string. This is very similiar to the<br />in
 * `string` _(string)_ 
 * `substring` _(string)_ 
 
-**Returns** _(boolean)_ 
-
 #### Example
 
 ```hbs

--- a/helpers/numbers/addOrdinalSuffix.js
+++ b/helpers/numbers/addOrdinalSuffix.js
@@ -16,7 +16,7 @@ function isSecond(num) {
   return mod10(num) === 2 && mod100(num) !== 12;
 }
 
-function isFourth(num) {
+function isThird(num) {
   return mod10(num) === 3 && mod100(num) !== 13;
 }
 
@@ -34,7 +34,7 @@ module.exports = function (num) {
     return `${num}st`;
   } else if (isSecond(num)) {
     return `${num}nd`;
-  } else if (isFourth(num)) {
+  } else if (isThird(num)) {
     return `${num}rd`;
   } else {
     return `${num}th`;

--- a/helpers/numbers/addOrdinalSuffix.js
+++ b/helpers/numbers/addOrdinalSuffix.js
@@ -1,26 +1,43 @@
 'use strict';
 
+function mod10(num) {
+  return num % 10;
+}
+
+function mod100(num) {
+  return num % 100;
+}
+
+function isFirst(num) {
+  return mod10(num) === 1 && mod100(num) !== 11;
+}
+
+function isSecond(num) {
+  return mod10(num) === 2 && mod100(num) !== 12;
+}
+
+function isFourth(num) {
+  return mod10(num) === 3 && mod100(num) !== 13;
+}
+
 /**
  * add ordinal after a number
  * e.g. `1` → `1st`, `2` → `2nd`, `3` → `3rd`
- * @param  {number|string} i number to add ordinal after
+ * @param  {number|string} num number to add ordinal after
  * @return {string}
  */
-module.exports = function (i) {
-  const j = i % 10,
-    k = i % 100;
-
+module.exports = function (num) {
   // if no number is supplied, pass through string
-  if (i === '' || isNaN(i)) { // will check numbers and (numbers in) strings
-    return new String(i); // will convert to a string if it's a different type
-  } else if (j === 1 && k !== 11) {
-    return i + 'st';
-  } else if (j === 2 && k !== 12) {
-    return i + 'nd';
-  } else if (j === 3 && k !== 13) {
-    return i + 'rd';
+  if (num === '' || isNaN(num)) { // will check numbers and (numbers in) strings
+    return new String(num); // will convert to a string if it's a different type
+  } else if (isFirst(num)) {
+    return `${num}st`;
+  } else if (isSecond(num)) {
+    return `${num}nd`;
+  } else if (isFourth(num)) {
+    return `${num}rd`;
   } else {
-    return i + 'th';
+    return `${num}th`;
   }
 };
 

--- a/helpers/strings/includes.js
+++ b/helpers/strings/includes.js
@@ -6,10 +6,14 @@
  *
  * @param  {string} string
  * @param  {string} substring
- * @return {boolean}
+ * @throws {Error} if either arg isn't a string
+ * @return {undefined|boolean}
  */
 module.exports = function (string, substring) {
-  if (!string || typeof string !== 'string' || typeof substring !== 'string') {
+  if (!string || !substring) {
+    return; // string may simply not be defined
+  } else if (typeof string !== 'string' || typeof substring !== 'string') {
+    // something's there, but it's not a string
     throw new Error('includes needs a string to search');
   } else {
     // Handlebars returns booleans as strings, so only return a value if the

--- a/helpers/strings/includes.js
+++ b/helpers/strings/includes.js
@@ -3,6 +3,8 @@
  * check if a substring exist within a string. This is very similiar to the
  * indexOf helper, except it uses String.prototype.includes() and returns a
  * boolean.
+ * note: handlebars returns booleans as strings, so only return a value if the substring is found
+ * otherwise, return undefined (rather than false)
  *
  * @param  {string} string
  * @param  {string} substring
@@ -15,12 +17,8 @@ module.exports = function (string, substring) {
   } else if (typeof string !== 'string' || typeof substring !== 'string') {
     // something's there, but it's not a string
     throw new Error('includes needs a string to search');
-  } else {
-    // Handlebars returns booleans as strings, so only return a value if the
-    // substring is found
-    if (string.includes(substring)) {
-      return true;
-    }
+  } else if (string.includes(substring)) {
+    return true;
   }
 };
 

--- a/helpers/strings/includes.test.js
+++ b/helpers/strings/includes.test.js
@@ -3,17 +3,21 @@ const name = getName(__filename),
   tpl = hbs.compile('{{ includes a b }}');
 
 describe(name, function () {
-  it('throws an error if no value passed in', function () {
+  it('returns empty if no value passed in', function () {
+    expect(tpl({a: null, b: 'test'})).to.be.empty;
+  });
+
+  it('throws an error if first arg is not string', function () {
     const result = function () {
-      return tpl({a: null, b: 'test'});
+      return tpl({a: 100, b: 'test'});
     };
 
     expect(result).to.throw(Error);
   });
 
-  it('throws an error if arguments are not strings', function () {
+  it('throws an error if second arg is not string', function () {
     const result = function () {
-      return tpl({a: 100, b: 'test'});
+      return tpl({a: 'test', b: 100});
     };
 
     expect(result).to.throw(Error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
@@ -1607,6 +1607,12 @@
       "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
       "dev": true
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -2511,33 +2517,33 @@
       }
     },
     "eslint": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.10.0.tgz",
-      "integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
+      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.0",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.1.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
+        "is-resolvable": "1.0.1",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -2591,13 +2597,12 @@
           }
         },
         "doctrine": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-          "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "2.0.2"
           }
         },
         "esprima": {
@@ -2606,10 +2611,10 @@
           "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+        "globals": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
+          "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
           "dev": true
         },
         "js-yaml": {
@@ -2652,20 +2657,26 @@
         "estraverse": "4.2.0"
       }
     },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         }
       }
@@ -2757,13 +2768,13 @@
       }
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
+        "chardet": "0.4.2",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       },
       "dependencies": {
@@ -4459,7 +4470,7 @@
         "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -4720,13 +4731,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -4766,13 +4777,10 @@
       }
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "dev": true
     },
     "is-ssh": {
       "version": "1.3.0",
@@ -4970,12 +4978,6 @@
       "dev": true,
       "optional": true
     },
-    "jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
-      "dev": true
-    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -5008,6 +5010,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -7323,7 +7331,7 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
         "lodash": "4.17.4",
@@ -7585,12 +7593,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
       "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
-      "dev": true
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "coveralls": "^2.11.15",
     "date-fns": "^1.28.2",
     "documentation": "4.0.0-beta15",
-    "eslint": "^4.4.1",
+    "eslint": "^4.15.0",
     "handlebars-template-loader": "^0.7.0",
     "istanbul": "^0.4.5",
     "lodash-webpack-plugin": "^0.11.2",


### PR DESCRIPTION
`includes` is sometimes called with `undefined` or `null` data, which should return falsy instead of throwing an error. Note: it should still throw an error if non-strings are passed in.