### PR TITLE
num helper should return NaN rather than erroring

### DIFF
--- a/helpers/numbers/num.js
+++ b/helpers/numbers/num.js
@@ -1,5 +1,4 @@
 'use strict';
-const _isNaN = require('lodash/isNaN');
 
 /**
  * converts things (usually strings) into numbers
@@ -8,13 +7,7 @@ const _isNaN = require('lodash/isNaN');
  * @return {string}
  */
 module.exports = function (x) {
-  const num = parseInt(x, 10);
-
-  if (!_isNaN(num)) {
-    return num;
-  } else {
-    throw new Error(`Cannot parse ${x} as number!`);
-  }
+  return parseInt(x, 10);;
 };
 
 module.exports.example = {

--- a/helpers/numbers/num.js
+++ b/helpers/numbers/num.js
@@ -7,7 +7,7 @@
  * @return {string}
  */
 module.exports = function (x) {
-  return parseInt(x, 10);;
+  return parseInt(x, 10);
 };
 
 module.exports.example = {

--- a/helpers/numbers/num.test.js
+++ b/helpers/numbers/num.test.js
@@ -11,11 +11,7 @@ describe(name, function () {
     expect(tpl({a: '123'})).to.equal('123');
   });
 
-  it('throws error if it cannot parse', function () {
-    const result = function () {
-      return tpl({a: []});
-    };
-
-    expect(result).to.throw(Error);
+  it('returns NaN for unparsable values', function () {
+    expect(tpl({a: []})).to.equal('NaN');
   });
 });


### PR DESCRIPTION
Throwing errors in templates is generally not a great practice, I'd rather render out `"NaN"` than have a page 500. In regards to combining helpers, in `sites` we use it alongside two other helpers `range` and `compare`, both of which are able to handle `NaN` values gracefully