### PR TITLE
make date-fns a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2234,8 +2234,7 @@
     "date-fns": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "date-now": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
     "coveralls": "^3.1.0",
-    "date-fns": "^1.30.1",
     "documentation": "4.0.0-beta15",
     "eslint": "^4.15.0",
     "handlebars-template-loader": "^0.7.0",
@@ -58,6 +57,7 @@
   },
   "dependencies": {
     "comma-it": "0.0.7",
+    "date-fns": "^1.30.1",
     "glob": "^7.1.6",
     "handlebars": "^4.7.6",
     "he": "^1.2.0",


### PR DESCRIPTION
with `date-fns` as a `devDependency`, `amphora-html` fails its tests:

```
 FAIL  lib/media.test.js
  ● Test suite failed to run

    Cannot find module 'date-fns/parse' from 'articleDate.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:221:17)
      at Object.<anonymous> (node_modules/clayhandlebars/helpers/time/articleDate.js:2:15)
```
