### PR TITLE
add try/catch to read helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const glob = require('glob'),
   path = require('path'),
   outdent = require('outdent'),

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const glob = require('glob'),
   path = require('path'),
   outdent = require('outdent'),
@@ -24,7 +25,11 @@ module.exports = function (env) {
   // support `read` helper on the server-side ONLY
   // todo: deprecate this when we figure out how to precompile these assets
   env.registerHelper('read', function (filename) {
-    return fs.readFileSync(filename, 'utf-8');
+    try {
+      return fs.readFileSync(filename, 'utf-8');
+    } catch (error) {
+      console.log(`Failure to read ${filename}. Error: ${error}`);
+    }
   });
 
   // add helpers


### PR DESCRIPTION
Handle `read` exceptions more gracefully.  Without this change, when a template tries to `read` a file that doesn't exist (e.g. an svg file), the entire page will fail to render, instead displaying this:

```
{
* 		errno: -2,
* 		syscall: "open",
* 		code: "ENOENT",
* 		path: "whatever/doesntexist.svg"
}
```

With this change, the page simply loads without the asset that doesn't exist and logs an error to the console.